### PR TITLE
add pyenv/bin to path before checking for pyenv executable

### DIFF
--- a/conf.d/pyenv.fish
+++ b/conf.d/pyenv.fish
@@ -1,14 +1,17 @@
-if not command -s pyenv > /dev/null
-    echo "pyenv: command not found. See https://github.com/yyuu/pyenv"
-    exit 1
-end
-
 set -l pyenv_root ''
 if test -z "$PYENV_ROOT"
     set pyenv_root "$HOME/.pyenv"
     set -x PYENV_ROOT "$HOME/.pyenv"
 else
     set pyenv_root "$PYENV_ROOT"
+end
+
+set -x PATH $pyenv_root/bin $PATH
+if not command -s pyenv > /dev/null
+    echo "pyenv: command not found. See https://github.com/yyuu/pyenv"
+    exit 1
+else
+    set --erase PYENV_ROOT
 end
 
 set -x PATH $pyenv_root/shims $PATH


### PR DESCRIPTION
Add pyenv/bin to path before checking for pyenv executable. Otherwise it doesn't work, at least not on my machine...the plugin looks for pyenv and cannot find it because its not in my PATH yet--that's what the plugin is supposed to do!