### PR TITLE
Fixes "The file '.' is not executable by this user"

### DIFF
--- a/functions/pyenv.fish
+++ b/functions/pyenv.fish
@@ -4,7 +4,7 @@ function pyenv
 
     switch "$command"
         case rehash shell
-            . (pyenv "sh-$command" $argv | psub)
+            source (pyenv "sh-$command" $argv | psub)
 
         case \*
             command pyenv "$command" $argv


### PR DESCRIPTION
```
~/.config/fish/functions/pyenv.fish (line 6): The file '.' is not executable by this user
            . (pyenv "sh-$command" $argv | psub)
            ^
in function 'pyenv'
	called on standard input
	with parameter list 'shell 3.6.2'
```

This fixes that. 