### PR TITLE
status is-login does not work for iTerm2 

### DIFF
--- a/conf.d/pyenv.fish
+++ b/conf.d/pyenv.fish
@@ -12,7 +12,7 @@ else
     set pyenv_root "$PYENV_ROOT"
 end
 
-if status --is-login
+if status --is-interactive
     set -x PATH "$pyenv_root/shims" $PATH
     set -x PYENV_SHELL fish
 end


### PR DESCRIPTION
changing is-login to is-interactive works for both iTerm2 and Terminal.

**Background:**
Installed pyenv using fisher.

`fisher pyenv`

Using Terminal, running `python` in a directory with `3.6.1` in `.python-version`, starts python 3.6.1. However, when I use iTerm2, same steps do not have same results. Typing `python` opens up the python 2.7.10 which is the default python shipped with Darwin.

Doing `which python` in both the pseudo terms result in different python executables too. In iTerm2
`/usr/bin/python` and in Terminal it goes to `/Users/tdasgupt/.pyenv/shims/python`. 

**Test:**
With the above change, correct version of `python` is picked up from the `.python-version` files. `env` shows `PATH` contains `PATH=/Users/tdasgupt/.pyenv/shims:` in both iTerm2 and Terminal. `which python` goes to `/Users/tdasgupt/.pyenv/shims/python` for both.

**Not tested:**
Any scenarios that is dependent on `status is-login` check in `pyenv/conf.d/pyenv.fish`. Also any scenario that will double execute this script so as to add the shim path despite it being added. _Not sure how to reproduce such a scenario_. If such a case exists, probably need to change to check if path has `pyenv/shim` before adding.