### PR TITLE
Get sh-prefixed commands directly from pyenv

### DIFF
--- a/functions/pyenv.fish
+++ b/functions/pyenv.fish
@@ -1,10 +1,12 @@
+set __pyenv_sh_commands (command pyenv commands --sh)
+
 function pyenv
     set command $argv[1]
     set -e argv[1]
 
     switch "$command"
-        case rehash shell
-            source (pyenv "sh-$command" $argv | psub)
+        case $__pyenv_sh_commands
+            source (command pyenv "sh-$command" $argv | psub)
 
         case \*
             command pyenv "$command" $argv


### PR DESCRIPTION
This fixes pyenv-virtualenv support, as the `pyenv` function would not properly call `sh-activiate` and `sh-deactivate`.

Also removed an unnecessary recursion into our own function definition.