### PR TITLE
Check interactive mode instead of login shell

### DIFF
--- a/conf.d/pyenv.fish
+++ b/conf.d/pyenv.fish
@@ -12,7 +12,7 @@ else
     set pyenv_root "$PYENV_ROOT"
 end
 
-if status --is-login
+if status --is-interactive
     set -x PATH "$pyenv_root/shims" $PATH
     set -x PYENV_SHELL fish
 end


### PR DESCRIPTION
Related to #12 where pyenv is not being initialized with this plugin.

The current `conf.d` script checks whether it is login shell or not, if so it will then set the `PATH` variable.
 
However, it never triggers in my system (I am using Arch) as I think because the fish shell is never used to Start X, even though fish is my default shell. Therefore, line 16-17 never ended up running. This is related to [this comment](https://github.com/fisherman/pyenv/issues/12#issuecomment-379172954)

I have changed the checking from checking if it's login-shell to checking if it's interactive shell, and it fixes the problem.