### PR TITLE
Update GitHub repository renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ fisher pyenv
 
 ## Notes
 
-You need <https://github.com/yyuu/pyenv> to use this plugin.
+You need <https://github.com/pyenv/pyenv> to use this plugin.
 
 This plugin replaces what `status --is-interactive; and . (pyenv init -|psub)`
 does in a more fishy way. This brings the startup time of your shell down
@@ -32,4 +32,4 @@ up your environment accordingly.
 [slack-link]: https://fisherman-wharf.herokuapp.com/
 [slack-badge]: https://fisherman-wharf.herokuapp.com/badge.svg
 [fisherman]: https://github.com/fisherman/fisherman
-[pyenv]: https://github.com/yyuu/pyenv
+[pyenv]: https://github.com/pyenv/pyenv

--- a/conf.d/pyenv.fish
+++ b/conf.d/pyenv.fish
@@ -1,5 +1,5 @@
 if not command -s pyenv > /dev/null
-    echo "Install <github.com/yyuu/pyenv> to use 'pyenv'."
+    echo "Install <github.com/pyenv/pyenv> to use 'pyenv'."
     exit 1
 end
 


### PR DESCRIPTION
Hello,

The repository of pyenv project <https://github.com/yyuu/pyenv> has been moved to <https://github.com/pyenv/pyenv>. So I updated documents and messages.